### PR TITLE
Update WandbLogger in configs to v2

### DIFF
--- a/training/v0.0.0/configs/config_-l-ctra_small.cfg
+++ b/training/v0.0.0/configs/config_-l-ctra_small.cfg
@@ -163,7 +163,7 @@ buffer = 256
 get_length = null
 
 [training.logger]
-@loggers = "spacy.WandbLogger.v1"
+@loggers = "spacy.WandbLogger.v2"
 project_name = "dacy-an-efficient-pipeline-for-danish"
 
 [training.optimizer]

--- a/training/v0.0.0/configs/config_conv_small.cfg
+++ b/training/v0.0.0/configs/config_conv_small.cfg
@@ -162,7 +162,7 @@ buffer = 256
 get_length = null
 
 [training.logger]
-@loggers = "spacy.WandbLogger.v1"
+@loggers = "spacy.WandbLogger.v2"
 project_name = "dacy-an-efficient-pipeline-for-danish"
 
 [training.optimizer]

--- a/training/v0.0.0/configs/config_electra_small.cfg
+++ b/training/v0.0.0/configs/config_electra_small.cfg
@@ -162,7 +162,7 @@ buffer = 256
 get_length = null
 
 [training.logger]
-@loggers = "spacy.WandbLogger.v1"
+@loggers = "spacy.WandbLogger.v2"
 project_name = "dacy-an-efficient-pipeline-for-danish"
 
 [training.optimizer]

--- a/training/v0.0.0/configs/config_large.cfg
+++ b/training/v0.0.0/configs/config_large.cfg
@@ -162,7 +162,7 @@ buffer = 256
 get_length = null
 
 [training.logger]
-@loggers = "spacy.WandbLogger.v1"
+@loggers = "spacy.WandbLogger.v2"
 project_name = "dacy-an-efficient-pipeline-for-danish"
 
 [training.optimizer]

--- a/training/v0.0.0/configs/config_medium.cfg
+++ b/training/v0.0.0/configs/config_medium.cfg
@@ -162,7 +162,7 @@ buffer = 256
 get_length = null
 
 [training.logger]
-@loggers = "spacy.WandbLogger.v1"
+@loggers = "spacy.WandbLogger.v2"
 project_name = "dacy-an-efficient-pipeline-for-danish"
 
 [training.optimizer]

--- a/training/v0.1.0/configs/config_large.cfg
+++ b/training/v0.1.0/configs/config_large.cfg
@@ -150,7 +150,7 @@ size = 2000
 buffer = 256
 
 [training.logger]
-@loggers = "spacy.WandbLogger.v1"
+@loggers = "spacy.WandbLogger.v2"
 project_name = "dacy-an-efficient-pipeline-for-danish"
 
 

--- a/training/v0.1.0/configs/config_medium.cfg
+++ b/training/v0.1.0/configs/config_medium.cfg
@@ -150,7 +150,7 @@ size = 2000
 buffer = 256
 
 [training.logger]
-@loggers = "spacy.WandbLogger.v1"
+@loggers = "spacy.WandbLogger.v2"
 project_name = "dacy-an-efficient-pipeline-for-danish"
 
 [training.optimizer]

--- a/training/v0.1.0/configs/config_small.cfg
+++ b/training/v0.1.0/configs/config_small.cfg
@@ -149,7 +149,7 @@ size = 2000
 buffer = 256
 
 [training.logger]
-@loggers = "spacy.WandbLogger.v1"
+@loggers = "spacy.WandbLogger.v2"
 project_name = "dacy-an-efficient-pipeline-for-danish"
 
 [training.optimizer]

--- a/training/v0.1.1/configs/config_large.cfg
+++ b/training/v0.1.1/configs/config_large.cfg
@@ -149,7 +149,7 @@ size = 2000
 buffer = 256
 
 [training.logger]
-@loggers = "spacy.WandbLogger.v1"
+@loggers = "spacy.WandbLogger.v2"
 project_name = "dacy-an-efficient-pipeline-for-danish"
 
 

--- a/training/v0.1.1/configs/config_medium.cfg
+++ b/training/v0.1.1/configs/config_medium.cfg
@@ -149,7 +149,7 @@ size = 2000
 buffer = 256
 
 [training.logger]
-@loggers = "spacy.WandbLogger.v1"
+@loggers = "spacy.WandbLogger.v2"
 project_name = "dacy-an-efficient-pipeline-for-danish"
 
 [training.optimizer]

--- a/training/v0.1.1/configs/config_small.cfg
+++ b/training/v0.1.1/configs/config_small.cfg
@@ -148,7 +148,7 @@ size = 2000
 buffer = 256
 
 [training.logger]
-@loggers = "spacy.WandbLogger.v1"
+@loggers = "spacy.WandbLogger.v2"
 project_name = "dacy-an-efficient-pipeline-for-danish"
 
 [training.optimizer]


### PR DESCRIPTION
Update WandbLogger in configs to v2. This version has the same experiment tracking features as v1 but also has model checkpointing and dataset versioning possibilities.   